### PR TITLE
Add daily detection helpers

### DIFF
--- a/SocialED/dataset/dataloader.py
+++ b/SocialED/dataset/dataloader.py
@@ -138,7 +138,30 @@ class DatasetLoader:
             str: The name of the dataset.
         """
         return self.dataset
-    
+
+
+    def slice_by_day(self, df=None):
+        """Split dataset into daily slices.
+
+        Parameters
+        ----------
+        df : pandas.DataFrame, optional
+            DataFrame to slice. If ``None`` use ``load_data()``.
+
+        Returns
+        -------
+        list of pandas.DataFrame
+            List with a DataFrame for each day sorted chronologically.
+        """
+        if df is None:
+            df = self.load_data()
+        df = df.copy()
+        df['created_at'] = pd.to_datetime(df['created_at'])
+        day_groups = []
+        for day in sorted(df['created_at'].dt.date.unique()):
+            day_groups.append(df[df['created_at'].dt.date == day].reset_index(drop=True))
+        return day_groups
+
 
 
     def get_dataset_info(self):

--- a/SocialED/detector/Hypersed.py
+++ b/SocialED/detector/Hypersed.py
@@ -282,6 +282,24 @@ class HyperSED:
         ari = metrics.adjusted_rand_score(ground_truths, predictions)
         print(f"Adjusted Rand Index (ARI): {ari}")
 
+    def detection_by_day(self):
+        """Run detection per-day."""
+        all_preds = []
+        all_truths = []
+        df = self.dataset.load_data()
+        df['created_at'] = pd.to_datetime(df['created_at'])
+        original_loader = self.dataset.load_data
+        for day in sorted(df['created_at'].dt.date.unique()):
+            subset = df[df['created_at'].dt.date == day].reset_index(drop=True)
+            self.dataset.load_data = lambda subset=subset: subset
+            self.preprocess()
+            self.fit()
+            gts, preds = self.detection()
+            all_preds.extend(preds)
+            all_truths.extend(gts)
+        self.dataset.load_data = original_loader
+        return all_truths, all_preds
+
 
 class Trainer(nn.Module):
     def __init__(self, args, block=None):

--- a/SocialED/detector/adpsemevent.py
+++ b/SocialED/detector/adpsemevent.py
@@ -61,6 +61,24 @@ class ADPSEMEvent:
         ari = metrics.adjusted_rand_score(ground_truths, predictions)
         print(f"Adjusted Rand Index (ARI): {ari}")
 
+    def detection_by_day(self):
+        """Run detection per-day."""
+        all_preds = []
+        all_truths = []
+        df = self.dataset.load_data()
+        df['created_at'] = pd.to_datetime(df['created_at'])
+        original_loader = self.dataset.load_data
+        for day in sorted(df['created_at'].dt.date.unique()):
+            subset = df[df['created_at'].dt.date == day].reset_index(drop=True)
+            self.dataset.load_data = lambda subset=subset: subset
+            self.preprocess()
+            self.fit()
+            gts, preds = self.detection()
+            all_preds.extend(preds)
+            all_truths.extend(gts)
+        self.dataset.load_data = original_loader
+        return all_truths, all_preds
+
 class Preprocessor:
     def __init__(self, dataset, mode='close'):
         """Initialize preprocessor

--- a/SocialED/detector/bert.py
+++ b/SocialED/detector/bert.py
@@ -138,5 +138,22 @@ class BERT:
 
         return ari, ami, nmi
 
+    def detection_by_day(self):
+        """Run detection separately for each day in the dataset."""
+        all_preds = []
+        all_truths = []
+        original_df = self.dataset.copy()
+        df = self.dataset.copy()
+        df['created_at'] = pd.to_datetime(df['created_at'])
+        for day in sorted(df['created_at'].dt.date.unique()):
+            self.dataset = df[df['created_at'].dt.date == day].reset_index(drop=True)
+            self.preprocess()
+            self.fit()
+            gts, preds = self.detection()
+            all_preds.extend(preds)
+            all_truths.extend(gts)
+        self.dataset = original_df
+        return all_truths, all_preds
+
 
 

--- a/SocialED/detector/bilstm.py
+++ b/SocialED/detector/bilstm.py
@@ -246,6 +246,23 @@ class BiLSTM:
         ari = metrics.adjusted_rand_score(ground_truths, predictions)
         print(f"Adjusted Rand Index (ARI): {ari}")
 
+    def detection_by_day(self):
+        """Run detection on each day separately."""
+        all_preds = []
+        all_truths = []
+        original_df = self.dataset.copy()
+        df = self.dataset.copy()
+        df['created_at'] = pd.to_datetime(df['created_at'])
+        for day in sorted(df['created_at'].dt.date.unique()):
+            self.dataset = df[df['created_at'].dt.date == day].reset_index(drop=True)
+            self.preprocess()
+            self.fit()
+            gts, preds = self.detection()
+            all_preds.extend(preds)
+            all_truths.extend(gts)
+        self.dataset = original_df
+        return all_truths, all_preds
+
     def run_train(self, epochs, model, train_iterator, test_iterator, optimizer, loss_func):
         """
         Run the training and evaluation process for the BiLSTM model.

--- a/SocialED/detector/clkd.py
+++ b/SocialED/detector/clkd.py
@@ -445,6 +445,24 @@ class CLKD:
         nmi = metrics.normalized_mutual_info_score(ground_truths, predictions)
         return ars, ami, nmi
 
+    def detection_by_day(self):
+        """Run detection per-day."""
+        all_preds = []
+        all_truths = []
+        df = self.dataset.load_data()
+        df['created_at'] = pd.to_datetime(df['created_at'])
+        original_loader = self.dataset.load_data
+        for day in sorted(df['created_at'].dt.date.unique()):
+            subset = df[df['created_at'].dt.date == day].reset_index(drop=True)
+            self.dataset.load_data = lambda subset=subset: subset
+            self.preprocess()
+            self.fit()
+            gts, preds = self.detection()
+            all_preds.extend(preds)
+            all_truths.extend(gts)
+        self.dataset.load_data = original_loader
+        return all_truths, all_preds
+
 class Preprocessor:
     def __init__(self, args):
         self.device = None

--- a/SocialED/detector/etgnn.py
+++ b/SocialED/detector/etgnn.py
@@ -215,6 +215,24 @@ class ETGNN:
 
         return val_f1, val_acc
 
+    def detection_by_day(self):
+        """Run detection per-day."""
+        all_preds = []
+        all_truths = []
+        df = self.dataset.load_data()
+        df['created_at'] = pd.to_datetime(df['created_at'])
+        original_loader = self.dataset.load_data
+        for day in sorted(df['created_at'].dt.date.unique()):
+            subset = df[df['created_at'].dt.date == day].reset_index(drop=True)
+            self.dataset.load_data = lambda subset=subset: subset
+            self.preprocess()
+            self.fit()
+            gts, preds = self.detection()
+            all_preds.extend(preds)
+            all_truths.extend(gts)
+        self.dataset.load_data = original_loader
+        return all_truths, all_preds
+
 
 class Preprocessor():
     def __init__(self,  args):

--- a/SocialED/detector/eventx.py
+++ b/SocialED/detector/eventx.py
@@ -145,6 +145,23 @@ class EventX:
         ari = metrics.adjusted_rand_score(ground_truths, predictions)
         print(f"Adjusted Rand Index (ARI): {ari}")
 
+    def detection_by_day(self):
+        """Run detection for each day separately."""
+        all_preds = []
+        all_truths = []
+        original_df = self.dataset.copy()
+        df = self.dataset.copy()
+        df['created_at'] = pd.to_datetime(df['created_at'])
+        for day in sorted(df['created_at'].dt.date.unique()):
+            self.dataset = df[df['created_at'].dt.date == day].reset_index(drop=True)
+            self.preprocess()
+            self.fit()
+            gts, preds = self.detection()
+            all_preds.extend(preds)
+            all_truths.extend(gts)
+        self.dataset = original_df
+        return all_truths, all_preds
+
     def construct_dict(self, df, dir_path=None):
         kw_pair_dict = {}
         kw_dict = {}

--- a/SocialED/detector/finevent.py
+++ b/SocialED/detector/finevent.py
@@ -346,6 +346,24 @@ class FinEvent:
         print(f"Model Normalized Mutual Information (NMI): {nmi}")
         return ars, ami, nmi
 
+    def detection_by_day(self):
+        """Run detection per-day."""
+        all_preds = []
+        all_truths = []
+        df = self.dataset.load_data()
+        df['created_at'] = pd.to_datetime(df['created_at'])
+        original_loader = self.dataset.load_data
+        for day in sorted(df['created_at'].dt.date.unique()):
+            subset = df[df['created_at'].dt.date == day].reset_index(drop=True)
+            self.dataset.load_data = lambda subset=subset: subset
+            self.preprocess()
+            self.fit()
+            gts, preds = self.detection()
+            all_preds.extend(preds)
+            all_truths.extend(gts)
+        self.dataset.load_data = original_loader
+        return all_truths, all_preds
+
 
 class FinEvent_model(FinEvent):
     def __init__(self, args) -> None:

--- a/SocialED/detector/glove.py
+++ b/SocialED/detector/glove.py
@@ -154,3 +154,21 @@ class GloVe:
         ari = metrics.adjusted_rand_score(ground_truths, predictions)
         print(f"Adjusted Rand Index (ARI): {ari}")
 
+    def detection_by_day(self):
+        """Run detection per-day."""
+        all_preds = []
+        all_truths = []
+        df = self.dataset.load_data()
+        df['created_at'] = pd.to_datetime(df['created_at'])
+        original_loader = self.dataset.load_data
+        for day in sorted(df['created_at'].dt.date.unique()):
+            subset = df[df['created_at'].dt.date == day].reset_index(drop=True)
+            self.dataset.load_data = lambda subset=subset: subset
+            self.preprocess()
+            self.fit()
+            gts, preds = self.detection()
+            all_preds.extend(preds)
+            all_truths.extend(gts)
+        self.dataset.load_data = original_loader
+        return all_truths, all_preds
+

--- a/SocialED/detector/hcrc.py
+++ b/SocialED/detector/hcrc.py
@@ -108,7 +108,9 @@ class HCRC:
 
                  # 设备相关参数
                  device: int = 0):
-        self.dataset = dataset.load_data()
+        # keep the dataset loader and preloaded dataframe
+        self.dataset = dataset
+        self.data = dataset.load_data()
         # 文件路径相关参数
         self.file_path = file_path
         self.result_path = result_path
@@ -139,7 +141,8 @@ class HCRC:
 
     def detection(self):
         args=self
-        unique_dates = sorted(self.dataset['created_at'].dt.date.unique())
+        df = self.data
+        unique_dates = sorted(df['created_at'].dt.date.unique())
         for i, day in enumerate(unique_dates):
             print("************Message Block "+str(i)+" start! ************")
             #Node-level learning
@@ -171,6 +174,10 @@ class HCRC:
         ground_truths = all_label
 
         return predictions, ground_truths
+
+    def detection_by_day(self):
+        """Compatibility helper mirroring :meth:`detection`."""
+        return self.detection()
 
     def evaluate(self, predictions, ground_truths):
         print("************Evaluation start! ************")

--- a/SocialED/detector/hisevent.py
+++ b/SocialED/detector/hisevent.py
@@ -57,6 +57,24 @@ class HISEvent():
         ari = metrics.adjusted_rand_score(ground_truths, predictions)
         print(f"Adjusted Rand Index (ARI): {ari}")
 
+    def detection_by_day(self):
+        """Run detection per-day."""
+        all_preds = []
+        all_truths = []
+        df = self.dataset.load_data()
+        df['created_at'] = pd.to_datetime(df['created_at'])
+        original_loader = self.dataset.load_data
+        for day in sorted(df['created_at'].dt.date.unique()):
+            subset = df[df['created_at'].dt.date == day].reset_index(drop=True)
+            self.dataset.load_data = lambda subset=subset: subset
+            self.preprocess()
+            self.fit()
+            gts, preds = self.detection()
+            all_preds.extend(preds)
+            all_truths.extend(gts)
+        self.dataset.load_data = original_loader
+        return all_truths, all_preds
+
 class Preprocessor:
     def __init__(self, dataset, mode='close'):
         """Initialize preprocessor

--- a/SocialED/detector/kpgnn.py
+++ b/SocialED/detector/kpgnn.py
@@ -325,6 +325,24 @@ class KPGNN():
         print(f"Model Normalized Mutual Information (NMI): {nmi}")
         return ars, ami, nmi
 
+    def detection_by_day(self):
+        """Run detection per-day."""
+        all_preds = []
+        all_truths = []
+        df = self.dataset.load_data()
+        df['created_at'] = pd.to_datetime(df['created_at'])
+        original_loader = self.dataset.load_data
+        for day in sorted(df['created_at'].dt.date.unique()):
+            subset = df[df['created_at'].dt.date == day].reset_index(drop=True)
+            self.dataset.load_data = lambda subset=subset: subset
+            self.preprocess()
+            self.fit()
+            gts, preds = self.detection()
+            all_preds.extend(preds)
+            all_truths.extend(gts)
+        self.dataset.load_data = original_loader
+        return all_truths, all_preds
+
 class Preprocessor:
     def __init__(self, dataset):
         pass

--- a/SocialED/detector/lda.py
+++ b/SocialED/detector/lda.py
@@ -192,4 +192,21 @@ class LDA:
             f.write(f"Adjusted Rand Index (ARI): {ari}\n")
             f.write("\n")  # Add a newline for better readability
 
+    def detection_by_day(self):
+        """Run detection separately for each day."""
+        all_preds = []
+        all_truths = []
+        original_df = self.dataset.copy()
+        df = self.dataset.copy()
+        df['created_at'] = pd.to_datetime(df['created_at'])
+        for day in sorted(df['created_at'].dt.date.unique()):
+            self.dataset = df[df['created_at'].dt.date == day].reset_index(drop=True)
+            self.preprocess()
+            self.fit()
+            gts, preds = self.detection()
+            all_preds.extend(preds)
+            all_truths.extend(gts)
+        self.dataset = original_df
+        return all_truths, all_preds
+
 

--- a/SocialED/detector/qsgnn.py
+++ b/SocialED/detector/qsgnn.py
@@ -317,6 +317,24 @@ class QSGNN:
         print(f"Model Normalized Mutual Information (NMI): {nmi}")
         return ars, ami, nmi
 
+    def detection_by_day(self):
+        """Run detection per-day."""
+        all_preds = []
+        all_truths = []
+        df = self.dataset.load_data()
+        df['created_at'] = pd.to_datetime(df['created_at'])
+        original_loader = self.dataset.load_data
+        for day in sorted(df['created_at'].dt.date.unique()):
+            subset = df[df['created_at'].dt.date == day].reset_index(drop=True)
+            self.dataset.load_data = lambda subset=subset: subset
+            self.preprocess()
+            self.fit()
+            gts, preds = self.detection()
+            all_preds.extend(preds)
+            all_truths.extend(gts)
+        self.dataset.load_data = original_loader
+        return all_truths, all_preds
+
 
 class Preprocessor(QSGNN):
     def __init__(self,dataser):

--- a/SocialED/detector/sbert.py
+++ b/SocialED/detector/sbert.py
@@ -113,4 +113,21 @@ class SBERT:
         ari = metrics.adjusted_rand_score(ground_truths, predictions)
         print(f"Adjusted Rand Index (ARI): {ari}")
 
+    def detection_by_day(self):
+        """Run detection for each day separately."""
+        all_preds = []
+        all_truths = []
+        original_df = self.dataset.copy()
+        df = self.dataset.copy()
+        df['created_at'] = pd.to_datetime(df['created_at'])
+        for day in sorted(df['created_at'].dt.date.unique()):
+            self.dataset = df[df['created_at'].dt.date == day].reset_index(drop=True)
+            self.preprocess()
+            self.fit()
+            gts, preds = self.detection()
+            all_preds.extend(preds)
+            all_truths.extend(gts)
+        self.dataset = original_df
+        return all_truths, all_preds
+
 

--- a/SocialED/detector/uclsed.py
+++ b/SocialED/detector/uclsed.py
@@ -207,6 +207,24 @@ class UCLSED:
 
         return val_f1, val_acc
 
+    def detection_by_day(self):
+        """Run detection per-day."""
+        all_preds = []
+        all_truths = []
+        df = self.dataset.load_data()
+        df['created_at'] = pd.to_datetime(df['created_at'])
+        original_loader = self.dataset.load_data
+        for day in sorted(df['created_at'].dt.date.unique()):
+            subset = df[df['created_at'].dt.date == day].reset_index(drop=True)
+            self.dataset.load_data = lambda subset=subset: subset
+            self.preprocess()
+            self.fit()
+            gts, preds = self.detection()
+            all_preds.extend(preds)
+            all_truths.extend(gts)
+        self.dataset.load_data = original_loader
+        return all_truths, all_preds
+
 
 class Preprocessor():
     def __init__(self,  args):

--- a/SocialED/detector/wmd.py
+++ b/SocialED/detector/wmd.py
@@ -204,6 +204,23 @@ class WMD:
             f.write(f"Adjusted Rand Index (ARI): {ari}\n")
             f.write("\n")
 
+    def detection_by_day(self):
+        """Run detection separately for each day."""
+        all_preds = []
+        all_truths = []
+        original_df = self.dataset.copy()
+        df = self.dataset.copy()
+        df['created_at'] = pd.to_datetime(df['created_at'])
+        for day in sorted(df['created_at'].dt.date.unique()):
+            self.dataset = df[df['created_at'].dt.date == day].reset_index(drop=True)
+            self.preprocess()
+            self.fit()
+            gts, preds = self.detection()
+            all_preds.extend(preds)
+            all_truths.extend(gts)
+        self.dataset = original_df
+        return all_truths, all_preds
+
 # 新增：计算单个文档的相似度
 def process_document(doc, instance, train_df, threshold, num_best):
     sims = instance[doc]

--- a/SocialED/detector/word2vec.py
+++ b/SocialED/detector/word2vec.py
@@ -150,4 +150,21 @@ class WORD2VEC:
 
         return ari, ami, nmi
 
+    def detection_by_day(self):
+        """Run detection on daily slices of the dataset."""
+        all_preds = []
+        all_truths = []
+        original_df = self.dataset.copy()
+        df = self.dataset.copy()
+        df['created_at'] = pd.to_datetime(df['created_at'])
+        for day in sorted(df['created_at'].dt.date.unique()):
+            self.dataset = df[df['created_at'].dt.date == day].reset_index(drop=True)
+            self.preprocess()
+            self.fit()
+            gts, preds = self.detection()
+            all_preds.extend(preds)
+            all_truths.extend(gts)
+        self.dataset = original_df
+        return all_truths, all_preds
+
 

--- a/notebooks/detector_examples.ipynb
+++ b/notebooks/detector_examples.ipynb
@@ -1,0 +1,147 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Detector Examples\nThis notebook demonstrates how to run different detectors on the `Event2012` dataset."
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "from SocialED.dataset import Event2012\nfrom SocialED.detector import LDA, BERT, SBERT, WORD2VEC, WMD, BiLSTM, EventX, HCRC"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "dataset = Event2012()\ndata = dataset.load_data()\nprint('Loaded', len(data), 'tweets')"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## LDA"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "lda = LDA(dataset)\nlda.preprocess()\nlda.fit()\ntruths, preds = lda.detection()\nlda.evaluate(truths, preds)"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "# Per-day detection\ntruths, preds = lda.detection_by_day()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## BERT"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "bert = BERT(dataset)\nbert.preprocess()\ntruths, preds = bert.detection()\nbert.evaluate(truths, preds)"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "truths, preds = bert.detection_by_day()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## SBERT"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "sbert = SBERT(dataset)\nsbert.preprocess()\ntruths, preds = sbert.detection()\nsbert.evaluate(truths, preds)"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "truths, preds = sbert.detection_by_day()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## WORD2VEC"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "w2v = WORD2VEC(dataset)\nw2v.preprocess()\nw2v.fit()\ntruths, preds = w2v.detection()\nw2v.evaluate(truths, preds)"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "truths, preds = w2v.detection_by_day()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## WMD"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "wmd = WMD(dataset)\nwmd.preprocess()\nwmd.fit()\ntruths, preds = wmd.detection()\nwmd.evaluate(truths, preds)"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "truths, preds = wmd.detection_by_day()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## BiLSTM"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "bilstm = BiLSTM(dataset)\nbilstm.preprocess()\nbilstm.fit()\ntruths, preds = bilstm.detection()\nbilstm.evaluate(truths, preds)"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "truths, preds = bilstm.detection_by_day()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## EventX"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "eventx = EventX(dataset)\neventx.preprocess()\neventx.fit()\ntruths, preds = eventx.detection()\neventx.evaluate(truths, preds)"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "truths, preds = eventx.detection_by_day()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## HCRC"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "hcrc = HCRC(dataset)\ntruths, preds = hcrc.detection()\nhcrc.evaluate(preds, truths)"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- refactor `HCRC` to keep dataset loader and data
- add `detection_by_day` helpers to remaining detectors
- allow per-day evaluation across the library

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685819afee5c83318a029396f06e69ac