### PR TITLE
Fix HCRC dropout issue and extend notebook examples

### DIFF
--- a/SocialED/detector/hcrc.py
+++ b/SocialED/detector/hcrc.py
@@ -1588,21 +1588,18 @@ def get_data(message_num,start,tweet_sum,save_path):
     true_y = torch.tensor(list(ini_df['event_id']))
 
     drop_percent = 0.2
+    drop_total = int(len(edge_index1[0]) * drop_percent)
     i = 0
-    while 1:
-        if i >= len(G.edges)*drop_percent:
-            break
-        m1 = random.randint(0, len(edge_index1[0])-1)
-        m2 = random.randint(0, len(edge_index2[0])-1)
-        if m1==m2:
+    while i < drop_total and len(edge_index1[0]) > 0 and len(edge_index2[0]) > 0:
+        m1 = random.randint(0, len(edge_index1[0]) - 1)
+        m2 = random.randint(0, len(edge_index2[0]) - 1)
+        if m1 == m2:
             continue
-        else:
-            del edge_index1[0][m1]
-            del edge_index1[1][m1]
-            del edge_index2[0][m2]
-            del edge_index2[1][m2]
-    
-        i = i + 1
+        del edge_index1[0][m1]
+        del edge_index1[1][m1]
+        del edge_index2[0][m2]
+        del edge_index2[1][m2]
+        i += 1
     edge_index = torch.tensor(edge_index)
     edge_index1 = torch.tensor(edge_index1)
     edge_index2 = torch.tensor(edge_index2)

--- a/notebooks/detector_examples.ipynb
+++ b/notebooks/detector_examples.ipynb
@@ -8,7 +8,7 @@
   {
    "cell_type": "code",
    "metadata": {},
-   "source": "from SocialED.dataset import Event2012\nfrom SocialED.detector import LDA, BERT, SBERT, WORD2VEC, WMD, BiLSTM, EventX, HCRC"
+   "source": "from SocialED.dataset import Event2012\nfrom SocialED.detector import LDA, BERT, SBERT, WORD2VEC, WMD, BiLSTM, EventX, HCRC, CLKD, ETGNN, FinEvent, GloVe, HISEvent, HyperSED, KPGNN, QSGNN, RPLMSED, UCLSED"
   },
   {
    "cell_type": "code",
@@ -129,6 +129,151 @@
    "cell_type": "code",
    "metadata": {},
    "source": "hcrc = HCRC(dataset)\ntruths, preds = hcrc.detection()\nhcrc.evaluate(preds, truths)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## CLKD"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "clkd = CLKD(dataset)\nclkd.preprocess()\nclkd.fit()\ntruths, preds = clkd.detection()\nclkd.evaluate(truths, preds)"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "truths, preds = clkd.detection_by_day()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## ETGNN"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "etgnn = ETGNN(dataset)\netgnn.preprocess()\netgnn.fit()\ntruths, preds = etgnn.detection()\netgnn.evaluate(truths, preds)"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "truths, preds = etgnn.detection_by_day()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## FinEvent"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "finevent = FinEvent(dataset)\nfinevent.preprocess()\nfinevent.fit()\ntruths, preds = finevent.detection()\nfinevent.evaluate(truths, preds)"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "truths, preds = finevent.detection_by_day()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## GloVe"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "glove = GloVe(dataset)\nglove.preprocess()\nglove.fit()\ntruths, preds = glove.detection()\nglove.evaluate(truths, preds)"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "truths, preds = glove.detection_by_day()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## HISEvent"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "hisevent = HISEvent(dataset)\nhisevent.preprocess()\ntruths, preds = hisevent.detection()\nhisevent.evaluate(truths, preds)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## HyperSED"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "hypersed = HyperSED(dataset)\nhypersed.preprocess()\nhypersed.fit()\ntruths, preds = hypersed.detection()\nhypersed.evaluate(truths, preds)"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "truths, preds = hypersed.detection_by_day()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## KPGNN"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "kpgnn = KPGNN(dataset)\nkpgnn.preprocess()\nkpgnn.fit()\ntruths, preds = kpgnn.detection()\nkpgnn.evaluate(truths, preds)"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "truths, preds = kpgnn.detection_by_day()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## QSGNN"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "qsgnn = QSGNN(dataset)\nqsgnn.preprocess()\nqsgnn.fit()\ntruths, preds = qsgnn.detection()\nqsgnn.evaluate(truths, preds)"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "truths, preds = qsgnn.detection_by_day()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## RPLMSED"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "rplmsed = RPLMSED(dataset)\nrplmsed.preprocess()\nrplmsed.fit()\ntruths, preds = rplmsed.detection()\nrplmsed.evaluate(truths, preds)"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "truths, preds = rplmsed.detection_by_day()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## UCLSED"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "uclsed = UCLSED(dataset)\nuclsed.preprocess()\nuclsed.fit()\ntruths, preds = uclsed.detection()\nuclsed.evaluate(truths, preds)"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "truths, preds = uclsed.detection_by_day()"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- avoid empty range error in `HCRC` when no tweet-level edges exist
- show how to use additional detectors in `notebooks/detector_examples.ipynb`

## Testing
- `pytest -q` *(fails: 22 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_685965a96e1083319387b881e9e4598d